### PR TITLE
feat: GitHub Actions ワークフロー追加 (closes #1)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,10 +15,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,39 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build-and-release:
+    name: Build exe and Create Release
+    runs-on: windows-latest
+
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install pyinstaller
+
+      - name: Build exe with PyInstaller
+        run: |
+          pyinstaller OsmoFileOrganize.spec
+
+      - name: Create GitHub Release and upload exe
+        uses: softprops/action-gh-release@v2
+        with:
+          files: dist/OsmoFileOrganize.exe
+          generate_release_notes: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,10 +15,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,33 @@
+name: Unit Tests
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - '**'
+
+jobs:
+  test:
+    name: Run Tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install -r requirements-dev.txt
+
+      - name: Run tests with coverage
+        run: |
+          pytest tests/ -v --cov=. --cov-report=term-missing


### PR DESCRIPTION
## 概要

Issue #1 の対応として、GitHub Actions ワークフローを 2 つ追加します。

Closes #1

---

## 変更内容

### ✅ ユニットテスト実行 (`.github/workflows/test.yml`)

- **トリガー**: `main` ブランチへの push、全ブランチへの Pull Request
- **実行環境**: `ubuntu-latest`
- Python 3.11 をセットアップし、`requirements.txt` と `requirements-dev.txt` をインストール
- `pytest` でユニットテストを実行し、カバレッジレポートを出力

### 📦 リリース時 exe 自動ビルド (`.github/workflows/release.yml`)

- **トリガー**: `v*` 形式のタグ push（例: `v1.0.0`）
- **実行環境**: `windows-latest`（Windows exe ビルドのため）
- PyInstaller + `OsmoFileOrganize.spec` で exe をビルド
- ビルドした `dist/OsmoFileOrganize.exe` を GitHub Release のアセットとして自動アップロード
- `generate_release_notes: true` により、リリースノートも自動生成

---

## 使い方

### テスト実行
PR を作成するか `main` にプッシュすると自動でテストが走ります。

### リリース
```bash
git tag v1.0.0
git push origin v1.0.0
```
タグをプッシュすると自動的に exe がビルドされ、GitHub Release が作成されます。
