### PR TITLE
CI: GUI へバージョン情報を記載

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,11 @@ jobs:
           pip install -r requirements.txt
           pip install pyinstaller
 
+      - name: Inject version info
+        shell: bash
+        run: |
+          sed -i "s/APP_VERSION = \"v0.0.0-dev\"/APP_VERSION = \"${{ github.ref_name }}\"/" main.py
+
       - name: Build exe with PyInstaller
         run: |
           pyinstaller OsmoFileOrganize.spec

--- a/main.py
+++ b/main.py
@@ -14,6 +14,12 @@ from organizer_core import (
 
 
 # ──────────────────────────────────────────────
+# 定数・設定
+# ──────────────────────────────────────────────
+APP_VERSION = "v0.0.0-dev"
+
+
+# ──────────────────────────────────────────────
 # メインアプリケーション
 # ──────────────────────────────────────────────
 
@@ -84,6 +90,11 @@ class OsmoOrganizerApp:
         title = ttk.Label(self.root, text="OSMO Pocket データ整理ツール",
                           font=("Yu Gothic UI", 16, "bold"))
         title.pack(anchor="w", padx=16, pady=(12, 4))
+
+        # バージョン表示 (右上に配置)
+        version_lbl = ttk.Label(self.root, text=APP_VERSION, 
+                                font=("Yu Gothic UI", 9), foreground="gray")
+        version_lbl.place(relx=1.0, rely=0.0, anchor="ne", x=-16, y=14)
 
         # 1. フォルダ選択
         self._build_folder_section()


### PR DESCRIPTION
Python から起動時は v0.0.0-dev と表示し、リリース時は付与したタグ情報を表示するように修正

Close #3 