### PR TITLE
softprops/action-gh-release のバージョンを v3 に更新

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
           pyinstaller OsmoFileOrganize.spec
 
       - name: Create GitHub Release and upload exe
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           files: dist/OsmoFileOrganize.exe
           generate_release_notes: true


### PR DESCRIPTION
Node.js の deprecated Warning を抑えるため、`softprops/action-gh-release` を `v2` から最新の `v3` にアップデートしました。

Close #5