### PR TITLE
feat: 不要な設定項目を整理し「整理設定」に統合 (Issue #9)

### DIFF
--- a/main.py
+++ b/main.py
@@ -50,7 +50,6 @@ class OsmoOrganizerApp:
         self.var_photo_folder = tk.StringVar(value="Photos")
         self.var_ignore_exts = tk.StringVar(value=".LRF, .THM")
         self.var_folder_order = tk.StringVar(value="日付 > 種類")
-        self.var_group_ext = tk.BooleanVar(value=False)
         self.var_video_exts = tk.StringVar(value=".MP4")
         self.var_photo_exts = tk.StringVar(value=".JPG, .DNG, .JPEG")
         self.var_misc_folder = tk.StringVar(value="Misc")
@@ -216,8 +215,8 @@ class OsmoOrganizerApp:
         self.ent_ignore_exts = ttk.Entry(ignore_row, textvariable=self.var_ignore_exts, width=12)
         self.ent_ignore_exts.pack(side="left", fill="x", expand=True, padx=(4, 0))
 
-        # --- 日付ごとの整理 ---
-        f_date = ttk.LabelFrame(cols, text="日付ごとの整理", padding=8)
+        # --- 整理設定 ---
+        f_date = ttk.LabelFrame(cols, text="整理設定", padding=8)
         f_date.grid(row=0, column=1, sticky="nsew", padx=4)
         ttk.Checkbutton(f_date, text="日付ごとにフォルダ分け",
                          variable=self.var_group_date,
@@ -233,6 +232,26 @@ class OsmoOrganizerApp:
         )
         self.combo_date_format.pack(side="left", padx=(4, 0))
         self.combo_date_format.bind("<<ComboboxSelected>>", lambda e: self._update_previews())
+
+        # 階層順序
+        order_row = ttk.Frame(f_date)
+        order_row.pack(fill="x", pady=(10, 0))
+        ttk.Label(order_row, text="階層順序").pack(side="left")
+        self.combo_folder_order = ttk.Combobox(
+            order_row, textvariable=self.var_folder_order,
+            values=(
+                "日付 > 種類", 
+                "種類 > 日付", 
+                "日付 > 種類 > 拡張子", 
+                "種類 > 日付 > 拡張子",
+                "日付 > 拡張子",
+                "種類 > 拡張子",
+                "拡張子 > 日付 > 種類"
+            ),
+            state="readonly", width=25
+        )
+        self.combo_folder_order.pack(side="left", padx=(4, 0))
+        self.combo_folder_order.bind("<<ComboboxSelected>>", lambda e: self._update_previews())
 
         # --- 動画/写真の整理 ---
         f_type = ttk.LabelFrame(cols, text="動画/写真の整理", padding=8)
@@ -271,37 +290,8 @@ class OsmoOrganizerApp:
         self.ent_photo_exts = ttk.Entry(p_ext_row, textvariable=self.var_photo_exts)
         self.ent_photo_exts.pack(side="left", fill="x", expand=True)
 
-        # --- 拡張子ごとの整理 ---
-        f_ext = ttk.LabelFrame(cols, text="拡張子ごとの整理", padding=8)
-        f_ext.grid(row=0, column=3, sticky="nsew", padx=4)
-        ttk.Checkbutton(f_ext, text="拡張子ごとにフォルダ分け",
-                         variable=self.var_group_ext,
-                         command=self._update_previews).pack(anchor="w", pady=2)
-        ttk.Label(f_ext, text="(例: /JPG, /MP4)", font=("Yu Gothic UI", 8, "italic"),
-                  foreground="gray").pack(anchor="w", padx=20)
-
-        # 列構成の重みを更新 (4列分)
-        cols.columnconfigure(3, weight=1)
-
-        # 階層順序
-        order_row = ttk.Frame(settings_group)
-        order_row.pack(fill="x", pady=(10, 0))
-        ttk.Label(order_row, text="階層順序").pack(side="left")
-        self.combo_folder_order = ttk.Combobox(
-            order_row, textvariable=self.var_folder_order,
-            values=(
-                "日付 > 種類", 
-                "種類 > 日付", 
-                "日付 > 種類 > 拡張子", 
-                "種類 > 日付 > 拡張子",
-                "日付 > 拡張子",
-                "種類 > 拡張子",
-                "拡張子 > 日付 > 種類"
-            ),
-            state="readonly", width=25
-        )
-        self.combo_folder_order.pack(side="left", padx=(4, 0))
-        self.combo_folder_order.bind("<<ComboboxSelected>>", lambda e: self._update_previews())
+        # 列構成の重みを更新 (3列分)
+        cols.columnconfigure(2, weight=1)
 
         # 変数の状態に合わせて有効/無効を切り替えるためのヘルパーを呼ぶ
         self.var_split_type.trace_add("write", lambda *args: self._update_entry_state())
@@ -402,7 +392,6 @@ class OsmoOrganizerApp:
                 video_folder=self.var_video_folder.get(),
                 photo_folder=self.var_photo_folder.get(),
                 misc_folder=self.var_misc_folder.get(),
-                group_ext=self.var_group_ext.get(),
                 folder_order=self.var_folder_order.get(),
             )
 

--- a/organizer_core.py
+++ b/organizer_core.py
@@ -112,7 +112,6 @@ def build_dest_path(
     video_folder: str,
     photo_folder: str,
     misc_folder: str,
-    group_ext: bool,
     folder_order: str,
 ) -> Path:
     """ファイル情報と整理設定から整理先の相対パスを生成する。
@@ -127,7 +126,6 @@ def build_dest_path(
         video_folder: 動画フォルダ名
         photo_folder: 写真フォルダ名
         misc_folder:  その他フォルダ名
-        group_ext:    拡張子ごとにフォルダ分けするか
         folder_order: 階層順序文字列（例: "日付 > 種類 > 拡張子"）
 
     Returns:
@@ -153,7 +151,7 @@ def build_dest_path(
         )
 
     # 拡張子セグメントの生成
-    ext_seg = file_path.suffix[1:].upper() if group_ext else None
+    ext_seg = file_path.suffix[1:].upper()
 
     # 階層順序に従ってセグメントを結合
     order_parts = [p.strip() for p in folder_order.split(">")]

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -229,7 +229,6 @@ class TestBuildDestPath:
             video_folder="Videos",
             photo_folder="Photos",
             misc_folder="Misc",
-            group_ext=False,
             folder_order="日付 > 種類",
         )
         defaults.update(kwargs)
@@ -308,10 +307,9 @@ class TestBuildDestPath:
     # ── 拡張子ごとの整理 ─────────────────────
 
     def test_group_by_ext(self, video_file):
-        """拡張子グループON → 拡張子フォルダが追加される"""
+        """階層順序に拡張子が含まれる → 拡張子フォルダが追加される"""
         result = self._build(
             video_file,
-            group_ext=True,
             folder_order="日付 > 種類 > 拡張子"
         )
         parts = result.parts
@@ -322,7 +320,6 @@ class TestBuildDestPath:
         result = self._build(
             photo_file,
             file_type="写真",
-            group_ext=True,
             folder_order="日付 > 種類 > 拡張子"
         )
         parts = result.parts


### PR DESCRIPTION
Issue #9 に基づき、設定画面の整理とロジックの改善を行いました。

### 変更内容
- **UIの整理**: 
  - 「拡張子ごとの整理」グループを削除
  - 「日付ごとの整理」を「整理設定」に改名
  - 「階層順序」を「整理設定」グループ内に移動
  - レイアウトを3列に最適化
- **ロジックの改善**: 
  - `organizer_core.py` の `build_dest_path` から `group_ext` 引数を削除
  - 階層順序の設定から拡張子フォルダの要否を自動判定するように変更
- **テストの更新**: 
  - 変更内容に合わせて `tests/test_core.py` を更新し、全テストのパスを確認済み

Closes #9