### PR TITLE
feat: Inno Setup によるインストーラー自動ビルドに対応 (Issue #7)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,6 +65,5 @@ jobs:
         uses: softprops/action-gh-release@v3
         with:
           files: |
-            dist/OsmoFileOrganize.exe
             dist/OsmoFileOrganize-Setup.exe
           generate_release_notes: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,6 +52,14 @@ jobs:
         run: |
           iscc /dMyAppVersion="${{ steps.version.outputs.ver }}" installer.iss
 
+      - name: Upload artifacts for verification
+        uses: actions/upload-artifact@v4
+        with:
+          name: OsmoFileOrganize-Build-${{ github.ref_name }}
+          path: |
+            dist/OsmoFileOrganize.exe
+            dist/OsmoFileOrganize-Setup.exe
+
       - name: Create GitHub Release and upload files
         if: startsWith(github.ref, 'refs/tags/')
         uses: softprops/action-gh-release@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,7 +58,7 @@ jobs:
         run: echo "sha7=$(echo ${GITHUB_SHA} | cut -c1-7)" >> $GITHUB_OUTPUT
 
       - name: Upload artifacts for verification
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: OsmoFileOrganize-Build-${{ steps.slug.outputs.sha7 }}
           path: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Upload artifacts for verification
         uses: actions/upload-artifact@v4
         with:
-          name: OsmoFileOrganize-Build-${{ github.ref_name }}
+          name: OsmoFileOrganize-Build
           path: |
             dist/OsmoFileOrganize.exe
             dist/OsmoFileOrganize-Setup.exe

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,10 +52,15 @@ jobs:
         run: |
           iscc /dMyAppVersion="${{ steps.version.outputs.ver }}" installer.iss
 
+      - name: Get short SHA
+        id: slug
+        shell: bash
+        run: echo "sha7=$(echo ${GITHUB_SHA} | cut -c1-7)" >> $GITHUB_OUTPUT
+
       - name: Upload artifacts for verification
         uses: actions/upload-artifact@v4
         with:
-          name: OsmoFileOrganize-Build
+          name: OsmoFileOrganize-Build-${{ steps.slug.outputs.sha7 }}
           path: |
             dist/OsmoFileOrganize.exe
             dist/OsmoFileOrganize-Setup.exe

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,10 +29,20 @@ jobs:
           pip install -r requirements.txt
           pip install pyinstaller
 
+      - name: Set version string
+        id: version
+        shell: bash
+        run: |
+          if [ "${{ github.event_name }}" == "pull_request" ]; then
+            echo "ver=PR #${{ github.event.number }} (Review)" >> $GITHUB_OUTPUT
+          else
+            echo "ver=${{ github.ref_name }}" >> $GITHUB_OUTPUT
+          fi
+
       - name: Inject version info
         shell: bash
         run: |
-          sed -i "s/APP_VERSION = \"v0.0.0-dev\"/APP_VERSION = \"${{ github.ref_name }}\"/" main.py
+          sed -i "s/APP_VERSION = \"v0.0.0-dev\"/APP_VERSION = \"${{ steps.version.outputs.ver }}\"/" main.py
 
       - name: Build exe with PyInstaller
         run: |
@@ -40,7 +50,7 @@ jobs:
 
       - name: Build Installer with Inno Setup
         run: |
-          iscc /dMyAppVersion="${{ github.ref_name }}" installer.iss
+          iscc /dMyAppVersion="${{ steps.version.outputs.ver }}" installer.iss
 
       - name: Create GitHub Release and upload files
         if: startsWith(github.ref, 'refs/tags/')

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - 'v*'
+  pull_request:
 
 jobs:
   build-and-release:
@@ -42,6 +43,7 @@ jobs:
           iscc /dMyAppVersion="${{ github.ref_name }}" installer.iss
 
       - name: Create GitHub Release and upload files
+        if: startsWith(github.ref, 'refs/tags/')
         uses: softprops/action-gh-release@v3
         with:
           files: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,8 +37,14 @@ jobs:
         run: |
           pyinstaller OsmoFileOrganize.spec
 
-      - name: Create GitHub Release and upload exe
+      - name: Build Installer with Inno Setup
+        run: |
+          iscc /dMyAppVersion="${{ github.ref_name }}" installer.iss
+
+      - name: Create GitHub Release and upload files
         uses: softprops/action-gh-release@v3
         with:
-          files: dist/OsmoFileOrganize.exe
+          files: |
+            dist/OsmoFileOrganize.exe
+            dist/OsmoFileOrganize-Setup.exe
           generate_release_notes: true

--- a/installer.iss
+++ b/installer.iss
@@ -21,8 +21,8 @@ Compression=lzma
 SolidCompression=yes
 WizardStyle=modern
 PrivilegesRequired=lowest
-DisableDirPage=yes
-DisableProgramGroupPage=yes
+DisableDirPage=no
+DisableProgramGroupPage=no
 
 [Languages]
 Name: "japanese"; MessagesFile: "compiler:Languages\Japanese.isl"

--- a/installer.iss
+++ b/installer.iss
@@ -1,0 +1,41 @@
+#define MyAppName "OsmoFileOrganize"
+#define MyAppPublisher "noriki-nakamura"
+#define MyAppURL "https://github.com/noriki-nakamura/OsmoFileOrgnizeGUI"
+#define MyAppExeName "OsmoFileOrganize.exe"
+
+[Setup]
+; NOTE: The value of AppId uniquely identifies this application. Do not use the same AppId value in installers for other applications.
+AppId={{9B7D9E4C-6C4F-4B1A-B4D3-9E4C6C4F4B1A}
+AppName={#MyAppName}
+AppVersion={#MyAppVersion}
+AppPublisher={#MyAppPublisher}
+AppPublisherURL={#MyAppURL}
+AppSupportURL={#MyAppURL}
+AppUpdatesURL={#MyAppURL}
+DefaultDirName={localappdata}\{#MyAppName}
+DefaultGroupName={#MyAppName}
+AllowNoIcons=yes
+OutputDir=dist
+OutputBaseFilename={#MyAppName}-Setup
+Compression=lzma
+SolidCompression=yes
+WizardStyle=modern
+PrivilegesRequired=lowest
+DisableDirPage=yes
+DisableProgramGroupPage=yes
+
+[Languages]
+Name: "japanese"; MessagesFile: "compiler:Languages\Japanese.isl"
+
+[Tasks]
+Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{cm:AdditionalIcons}"; Flags: unchecked
+
+[Files]
+Source: "dist\{#MyAppExeName}"; DestDir: "{app}"; Flags: ignoreversion
+
+[Icons]
+Name: "{group}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"
+Name: "{autodesktop}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"; Tasks: desktopicon
+
+[Run]
+Filename: "{app}\{#MyAppExeName}"; Description: "{cm:LaunchProgram,{#StringChange(MyAppName, '&', '&&')}}"; Flags: nowait postinstall skipifsilent


### PR DESCRIPTION
Issue #7 に基づき、Windows 用インストーラー（Setup.exe）の自動生成およびリリースフローへの統合を実装しました。

### 変更内容
- **インストーラースクリプト**: `installer.iss` (Inno Setup) を新規作成しました。
  - 管理者権限不要でインストール可能
  - 日本語対応
  - デスクトップ/スタートメニューのショートカット作成
- **CI/CD ワークフロー**: `.github/workflows/release.yml` を更新しました。
  - リリース（タグ push）時にインストーラーを自動ビルドし、アセットとしてアップロード
  - **新規追加**: Pull Request 時にもビルド検証が走るように設定（リリースはスキップ）

Closes #7